### PR TITLE
Fix casing of assembly and updated several URLs including ArcGIS and WorldWind

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 OpenGlobe
 =========
 
-<center>
-![Screen shot of Half Dome as rendered by OpenGlobe](http://www.virtualglobebook.com/halfdome.jpg)
-</center>
+![Screen shot of Half Dome as rendered by OpenGlobe](https://virtualglobebook.com/halfdome.jpg)
 
 **Note: OpenGlobe is great for learning along with our book, 3D Engine Design for Virtual Globes.  But for a production quality, open source, virtual globe by the same authors (plus more), check out [Cesium](https://cesiumjs.org)!**
 
-OpenGlobe is a 3D engine for virtual globes (think [Google Earth](http://earth.google.com) or [NASA World Wind](http://worldwind.arc.nasa.gov)) designed to illustrate the engine design and rendering techniques described in our book, [3D Engine Design for Virtual Globes](http://www.virtualglobebook.com).  It is written in C# (with full support for running on Linux using [Mono](http://www.mono-project.com)) and uses the OpenGL 3.3 core profile via [OpenTK](http://www.opentk.com).  It is not a complete virtual globe application, but is rather a core engine and a number of runnable examples.
+OpenGlobe is a 3D engine for virtual globes (think [Google Earth](https://earth.google.com) or [NASA World Wind](https://worldwind.arc.nasa.gov)) designed to illustrate the engine design and rendering techniques described in our book, [3D Engine Design for Virtual Globes](https://virtualglobebook.com).  It is written in C# (with full support for running on Linux using [Mono](https://www.mono-project.com/)) and uses the OpenGL 3.3 core profile via [OpenTK](https://opentk.net/). It is not a complete virtual globe application, but is rather a core engine and a number of runnable examples.
 
 OpenGlobe has the following features and capabilities:
 
@@ -21,7 +19,7 @@ OpenGlobe has the following features and capabilities:
 - Terrain shading using procedural techniques.
 - Whole-world terrain and imagery rendering on an accurate WGS84 globe using geometry clipmapping.
 
-The code (and the book) draw from the authors' real-world experience working on [STK](http://www.agi.com), one of the earliest commercial virtual globes.  Since it is intended as a learning aid, the code is written in a style that we hope is easy to understand and follow, especially when accompanied by the book.
+The code (and the book) draw from the authors' real-world experience working on [STK](https://www.agi.com), one of the earliest commercial virtual globes.  Since it is intended as a learning aid, the code is written in a style that we hope is easy to understand and follow, especially when accompanied by the book.
 
-For information on getting up and running with the code on both Windows and Linux, see the instructions [here](http://www.virtualglobebook.com/code.html).
+For information on getting up and running with the code on both Windows and Linux, see the instructions [here](https://virtualglobebook.com/code.html).
 

--- a/Source/Renderer/OpenGlobe.Renderer.csproj
+++ b/Source/Renderer/OpenGlobe.Renderer.csproj
@@ -40,7 +40,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BlittableBGRA.cs" />

--- a/Source/Scene/Terrain/EsriRestImagery.cs
+++ b/Source/Scene/Terrain/EsriRestImagery.cs
@@ -14,7 +14,7 @@ namespace OpenGlobe.Scene
     public class EsriRestImagery : RasterSource
     {
         public EsriRestImagery() :
-            this(new Uri("http://server.arcgisonline.com/ArcGIS/rest/services/ESRI_Imagery_World_2D/MapServer/tile/"))
+            this(new Uri("https://wi.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/"))
         {
         }
 

--- a/Source/Scene/Terrain/WorldWindTerrainSource.cs
+++ b/Source/Scene/Terrain/WorldWindTerrainSource.cs
@@ -20,7 +20,7 @@ namespace OpenGlobe.Scene
     public class WorldWindTerrainSource : RasterSource
     {
         public WorldWindTerrainSource() :
-            this(new Uri("http://www.nasa.network.com/elev?service=WMS&request=GetMap&version=1.3&srs=EPSG:4326&layers=mergedElevations&styles=&format=application/bil16&bgColor=-9999.0&width=150&height=150"))
+            this(new Uri("https://worldwind26.arc.nasa.gov/elev?service=WMS&request=GetMap&version=1.3&srs=EPSG:4326&layers=mergedElevations&styles=&format=application/bil16&bgColor=-9999.0&width=150&height=150"))
         {
         }
 


### PR DESCRIPTION
The following _reference include_ in `Source/Renderer/OpenGlobe.Renderer.csproj` caused an error on Linux (Mono) due to casing of "XML":

```xml
<Reference Include="System.XML" />
```